### PR TITLE
Add support for file download path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "bulk-data-client": "git+https://git@github.com/smart-on-fhir/bulk-data-client",
         "colors": "^1.4.0",
         "commander": "^9.4.1",
-        "prompt-sync": "^4.2.0",
         "ts-node": "^10.9.1",
         "ts-node-dev": "^2.0.0"
       },
@@ -21,7 +20,6 @@
         "@types/jest": "^29.1.2",
         "@types/jsonwebtoken": "^8.5.9",
         "@types/node-jose": "^1.1.10",
-        "@types/prompt-sync": "^4.2.0",
         "@typescript-eslint/eslint-plugin": "^5.40.0",
         "@typescript-eslint/parser": "^5.40.0",
         "eslint": "^8.25.0",
@@ -1411,12 +1409,6 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
       "integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
-      "dev": true
-    },
-    "node_modules/@types/prompt-sync": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@types/prompt-sync/-/prompt-sync-4.2.0.tgz",
-      "integrity": "sha512-5RPQYDT7MNkt+vq6xp58tSPx4THANyQcBSaw3Ni+KV7MUAgvUUbmCsQmcPVrcc8dwuURSPixz2qTJdJF6ABSKw==",
       "dev": true
     },
     "node_modules/@types/responselike": {
@@ -7068,12 +7060,6 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
       "integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
-      "dev": true
-    },
-    "@types/prompt-sync": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@types/prompt-sync/-/prompt-sync-4.2.0.tgz",
-      "integrity": "sha512-5RPQYDT7MNkt+vq6xp58tSPx4THANyQcBSaw3Ni+KV7MUAgvUUbmCsQmcPVrcc8dwuURSPixz2qTJdJF6ABSKw==",
       "dev": true
     },
     "@types/responselike": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bulk-data-client": "git+https://git@github.com/smart-on-fhir/bulk-data-client",
+        "colors": "^1.4.0",
         "commander": "^9.4.1",
+        "prompt-sync": "^4.2.0",
         "ts-node": "^10.9.1",
         "ts-node-dev": "^2.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,9 @@
   },
   "dependencies": {
     "bulk-data-client": "git+https://git@github.com/smart-on-fhir/bulk-data-client",
+    "colors": "^1.4.0",
     "commander": "^9.4.1",
+    "prompt-sync": "^4.2.0",
     "ts-node": "^10.9.1",
     "ts-node-dev": "^2.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@types/jest": "^29.1.2",
     "@types/jsonwebtoken": "^8.5.9",
     "@types/node-jose": "^1.1.10",
-    "@types/prompt-sync": "^4.2.0",
     "@typescript-eslint/eslint-plugin": "^5.40.0",
     "@typescript-eslint/parser": "^5.40.0",
     "eslint": "^8.25.0",
@@ -54,7 +53,6 @@
     "bulk-data-client": "git+https://git@github.com/smart-on-fhir/bulk-data-client",
     "colors": "^1.4.0",
     "commander": "^9.4.1",
-    "prompt-sync": "^4.2.0",
     "ts-node": "^10.9.1",
     "ts-node-dev": "^2.0.0"
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,7 +45,7 @@ const main = async () => {
   } as Types.NormalizedOptions;
 
   if (!fs.existsSync(program.opts().destination)) {
-    console.log( `Destination ${program.opts().destination} does not exist.`);
+    console.log(`Destination ${program.opts().destination} does not exist.`);
     const makeDir = prompt()('Make new directory? [y/n] '.cyan);
     if (makeDir.toLowerCase() === 'y') {
       fs.mkdirSync(program.opts().destination, { recursive: true });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,7 +48,7 @@ const main = async () => {
     console.log(`Destination ${program.opts().destination} does not exist.`);
     const rl = readline.createInterface({
       input: process.stdin,
-      output: process.stdout
+      output: process.stdout,
     });
     const answer = await rl.question('Make new directory? [y/n]');
     if (answer.toLowerCase() === 'y') {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
+import { resolve } from 'path';
+import fs from 'fs';
 import { BulkDataClient as Types } from 'bulk-data-client';
 import BulkDataClient from 'bulk-data-client/built/lib/BulkDataClient';
 import CLIReporter from 'bulk-data-client/built/reporters/cli';
@@ -10,12 +12,18 @@ const program = new Command();
 program
   .requiredOption('-f, --fhir-url <url>', 'Base URL of FHIR server used for data retrieval')
   .requiredOption('-g, --group <id>', 'FHIR Group ID used to query FHIR server for resources')
-  .option('-d, --destination <destination>', 'Download destination. Defaults to ./downloads', './downloads')
+  .option(
+    '-d, --destination <destination>',
+    'Download destination relative to current working directory. Defaults to ./downloads',
+    `${process.cwd()}/downloads`
+  )
   .option('-p, --parallel-downloads <number>', 'Number of downloads to run in parallel. Defaults to 1.', '1')
   .parseAsync(process.argv);
 
 // add required trailing slash to FHIR URL if not present
 program.opts().fhirUrl = program.opts().fhirUrl.replace(/\/*$/, '/');
+// get absolute path for specified destination directory
+program.opts().destination = resolve(program.opts().destination);
 
 const main = async () => {
   const requests = {
@@ -33,6 +41,11 @@ const main = async () => {
     ...program.opts(),
     requests,
   } as Types.NormalizedOptions;
+
+  if (!fs.existsSync(program.opts().destination)) {
+    fs.mkdirSync(program.opts().destination, { recursive: true });
+  }
+
   const client = new BulkDataClient(options as Types.NormalizedOptions);
   CLIReporter(client);
   const statusEndpoint = await client.kickOff();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@
 
 import { Command } from 'commander';
 import { resolve } from 'path';
-import prompt from 'prompt-sync';
+import * as readline from 'readline/promises';
 import fs from 'fs';
 import 'colors';
 import { BulkDataClient as Types } from 'bulk-data-client';
@@ -46,13 +46,18 @@ const main = async () => {
 
   if (!fs.existsSync(program.opts().destination)) {
     console.log(`Destination ${program.opts().destination} does not exist.`);
-    const makeDir = prompt()('Make new directory? [y/n] '.cyan);
-    if (makeDir.toLowerCase() === 'y') {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout
+    });
+    const answer = await rl.question('Make new directory? [y/n]');
+    if (answer.toLowerCase() === 'y') {
       fs.mkdirSync(program.opts().destination, { recursive: true });
     } else {
       console.error('Exiting due to non-existent destination.'.red);
       process.exit();
     }
+    rl.close();
   }
 
   const client = new BulkDataClient(options as Types.NormalizedOptions);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,9 @@
 
 import { Command } from 'commander';
 import { resolve } from 'path';
+import prompt from 'prompt-sync';
 import fs from 'fs';
+import 'colors';
 import { BulkDataClient as Types } from 'bulk-data-client';
 import BulkDataClient from 'bulk-data-client/built/lib/BulkDataClient';
 import CLIReporter from 'bulk-data-client/built/reporters/cli';
@@ -43,7 +45,14 @@ const main = async () => {
   } as Types.NormalizedOptions;
 
   if (!fs.existsSync(program.opts().destination)) {
-    fs.mkdirSync(program.opts().destination, { recursive: true });
+    console.log( `Destination ${program.opts().destination} does not exist.`);
+    const makeDir = prompt()('Make new directory? [y/n] '.cyan);
+    if (makeDir.toLowerCase() === 'y') {
+      fs.mkdirSync(program.opts().destination, { recursive: true });
+    } else {
+      console.error('Exiting due to non-existent destination.'.red);
+      process.exit();
+    }
   }
 
   const client = new BulkDataClient(options as Types.NormalizedOptions);


### PR DESCRIPTION
Adds better support for specifying the download path from the CLI.

## Code changes
* Use current working directory to specify the default download path if not defined by the user
* Get absolute path for specified destination directory via `path.resolve()`
* If the specified download path does not exist, prompts the user about making new directory. Exits if user does not want to create new directory. Otherwise, makes new directory and continues the export flow.

# Testing Guidance
* Check that the default value for the `-d` flag works as expected
* Check that specifying a relative path will correctly grab the absolute path and write files to the specified directory
* Test the prompt (specifying y/n for creating the new directory) and see whether this is a good approach to use for this situation - I figure if a user makes a typo when specifying the directory and they end up specifying a directory that does not exist, they will want to exit and re-run the CLI with the correct directory