### PR TITLE
Bulk Data Authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ The supported options for making a request to a FHIR server are as follows:
 -g, --group-id <id>             FHIR Group ID used to query FHIR server for resources.
 -d, --destination <destination> Download destination of exported files.
 -p, --parallel-downloads <number> Number of downloads to run in parallel.
+--token-url <tokenUrl> Bulk Token Authorization Endpoint
+--client-id <clientId> Bulk Data Client ID
+--private-key <url> File containing private key used to sign authentication tokens
 ```
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "bulk-data-client": "git+https://git@github.com/bulk-dqm/bulk-data-client#fix-download",
+        "bulk-data-client": "git+https://git@github.com/smart-on-fhir/bulk-data-client",
         "colors": "^1.4.0",
         "commander": "^9.4.1",
         "fqm-execution": "^1.0.1",
-        "jose": "^2.0.0",
+        "node-jose": "^2.0.0",
         "ts-node": "^10.9.1",
         "ts-node-dev": "^2.0.0"
       },
@@ -1234,14 +1234,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@panva/asn1.js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz",
-      "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==",
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.51",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
@@ -2092,8 +2084,8 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/bulk-data-client": {
-      "version": "1.1.0",
-      "resolved": "git+https://git@github.com/bulk-dqm/bulk-data-client.git#c052c55848164c41185a5ecc6ff21d5354a99481",
+      "version": "1.1.1",
+      "resolved": "git+https://git@github.com/smart-on-fhir/bulk-data-client.git#4eaaa8208b31e543aa7a2c7f175c79c0d6221009",
       "license": "ISC",
       "dependencies": {
         "@hapi/code": "^8.0.3",
@@ -4383,20 +4375,6 @@
       "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
       "engines": {
         "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/jose": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.6.tgz",
-      "integrity": "sha512-FVoPY7SflDodE4lknJmbAHSUjLCzE2H1F6MS0RYKMQ8SR+lNccpMf8R4eqkNYyyUjR5qZReOzZo5C5YiHOCjjg==",
-      "dependencies": {
-        "@panva/asn1.js": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10.13.0 < 13 || >=13.7.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-sdsl": {
@@ -7459,11 +7437,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@panva/asn1.js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz",
-      "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw=="
-    },
     "@sinclair/typebox": {
       "version": "0.24.51",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
@@ -8098,8 +8071,8 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "bulk-data-client": {
-      "version": "git+https://git@github.com/bulk-dqm/bulk-data-client.git#c052c55848164c41185a5ecc6ff21d5354a99481",
-      "from": "bulk-data-client@git+https://git@github.com/bulk-dqm/bulk-data-client#fix-download",
+      "version": "git+https://git@github.com/smart-on-fhir/bulk-data-client.git#4eaaa8208b31e543aa7a2c7f175c79c0d6221009",
+      "from": "bulk-data-client@git+https://git@github.com/smart-on-fhir/bulk-data-client",
       "requires": {
         "@hapi/code": "^8.0.3",
         "aws-sdk": "^2.987.0",
@@ -9812,14 +9785,6 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
       "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
-    },
-    "jose": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.6.tgz",
-      "integrity": "sha512-FVoPY7SflDodE4lknJmbAHSUjLCzE2H1F6MS0RYKMQ8SR+lNccpMf8R4eqkNYyyUjR5qZReOzZo5C5YiHOCjjg==",
-      "requires": {
-        "@panva/asn1.js": "^1.0.0"
-      }
     },
     "js-sdsl": {
       "version": "4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,11 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "bulk-data-client": "git+https://git@github.com/smart-on-fhir/bulk-data-client",
+        "bulk-data-client": "git+https://git@github.com/bulk-dqm/bulk-data-client#fix-download",
         "colors": "^1.4.0",
         "commander": "^9.4.1",
         "fqm-execution": "^1.0.1",
+        "jose": "^2.0.0",
         "ts-node": "^10.9.1",
         "ts-node-dev": "^2.0.0"
       },
@@ -1233,6 +1234,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@panva/asn1.js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz",
+      "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw==",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.51",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
@@ -2084,7 +2093,7 @@
     },
     "node_modules/bulk-data-client": {
       "version": "1.1.0",
-      "resolved": "git+https://git@github.com/smart-on-fhir/bulk-data-client.git#65ae091ad36592078e738df6a9ee397b47113901",
+      "resolved": "git+https://git@github.com/bulk-dqm/bulk-data-client.git#c052c55848164c41185a5ecc6ff21d5354a99481",
       "license": "ISC",
       "dependencies": {
         "@hapi/code": "^8.0.3",
@@ -4374,6 +4383,20 @@
       "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
       "engines": {
         "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.6.tgz",
+      "integrity": "sha512-FVoPY7SflDodE4lknJmbAHSUjLCzE2H1F6MS0RYKMQ8SR+lNccpMf8R4eqkNYyyUjR5qZReOzZo5C5YiHOCjjg==",
+      "dependencies": {
+        "@panva/asn1.js": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.13.0 < 13 || >=13.7.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-sdsl": {
@@ -7436,6 +7459,11 @@
         "fastq": "^1.6.0"
       }
     },
+    "@panva/asn1.js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@panva/asn1.js/-/asn1.js-1.0.0.tgz",
+      "integrity": "sha512-UdkG3mLEqXgnlKsWanWcgb6dOjUzJ+XC5f+aWw30qrtjxeNUSfKX1cd5FBzOaXQumoe9nIqeZUvrRJS03HCCtw=="
+    },
     "@sinclair/typebox": {
       "version": "0.24.51",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
@@ -8070,8 +8098,8 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "bulk-data-client": {
-      "version": "git+https://git@github.com/smart-on-fhir/bulk-data-client.git#65ae091ad36592078e738df6a9ee397b47113901",
-      "from": "bulk-data-client@git+https://git@github.com/smart-on-fhir/bulk-data-client",
+      "version": "git+https://git@github.com/bulk-dqm/bulk-data-client.git#c052c55848164c41185a5ecc6ff21d5354a99481",
+      "from": "bulk-data-client@git+https://git@github.com/bulk-dqm/bulk-data-client#fix-download",
       "requires": {
         "@hapi/code": "^8.0.3",
         "aws-sdk": "^2.987.0",
@@ -9784,6 +9812,14 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
       "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
+    },
+    "jose": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-2.0.6.tgz",
+      "integrity": "sha512-FVoPY7SflDodE4lknJmbAHSUjLCzE2H1F6MS0RYKMQ8SR+lNccpMf8R4eqkNYyyUjR5qZReOzZo5C5YiHOCjjg==",
+      "requires": {
+        "@panva/asn1.js": "^1.0.0"
+      }
     },
     "js-sdsl": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -51,12 +51,12 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
-    "bulk-data-client": "git+https://git@github.com/bulk-dqm/bulk-data-client#fix-download",
+    "bulk-data-client": "git+https://git@github.com/smart-on-fhir/bulk-data-client",
     "colors": "^1.4.0",
     "commander": "^9.4.1",
     "fqm-execution": "^1.0.1",
     "ts-node": "^10.9.1",
     "ts-node-dev": "^2.0.0",
-    "jose": "^2.0.0"
+    "node-jose": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,11 +51,12 @@
     "typescript": "^4.8.4"
   },
   "dependencies": {
-    "bulk-data-client": "git+https://git@github.com/smart-on-fhir/bulk-data-client",
+    "bulk-data-client": "git+https://git@github.com/bulk-dqm/bulk-data-client#fix-download",
     "colors": "^1.4.0",
     "commander": "^9.4.1",
     "fqm-execution": "^1.0.1",
     "ts-node": "^10.9.1",
-    "ts-node-dev": "^2.0.0"
+    "ts-node-dev": "^2.0.0",
+    "jose": "^2.0.0"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import 'colors';
 import { BulkDataClient as Types } from 'bulk-data-client';
 import BulkDataClient from 'bulk-data-client/built/lib/BulkDataClient';
 import CLIReporter from 'bulk-data-client/built/reporters/cli';
+import { resolveJWK } from './jwk';
 const program = new Command();
 
 // specify options for bulk data request and retrieval
@@ -20,6 +21,9 @@ program
     `${process.cwd()}/downloads`
   )
   .option('-p, --parallel-downloads <number>', 'Number of downloads to run in parallel. Defaults to 1.', '1')
+  .option('--token-url <tokenUrl>', 'Bulk Token Authorization Endpoint')
+  .option('--client-id <clientId>', 'Bulk Data Client ID')
+  .option('--private-key <url>', 'File or URL of private key used to sign authentication tokens')
   .parseAsync(process.argv);
 
 // add required trailing slash to FHIR URL if not present
@@ -39,8 +43,13 @@ const main = async () => {
     },
   };
 
+  if (program.opts().privateKey) {
+    program.opts().privateKey = await resolveJWK(program.opts().privateKey);
+  }
+
   const options = {
     ...program.opts(),
+    inlineDocRefAttachmentTypes: [],
     requests,
   } as Types.NormalizedOptions;
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,7 +23,7 @@ program
   .option('-p, --parallel-downloads <number>', 'Number of downloads to run in parallel. Defaults to 1.', '1')
   .option('--token-url <tokenUrl>', 'Bulk Token Authorization Endpoint')
   .option('--client-id <clientId>', 'Bulk Data Client ID')
-  .option('--private-key <url>', 'File or URL of private key used to sign authentication tokens')
+  .option('--private-key <url>', 'File containing private key used to sign authentication tokens')
   .parseAsync(process.argv);
 
 // add required trailing slash to FHIR URL if not present

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { Command } from 'commander';
+import { Command, OptionValues } from 'commander';
 import { resolve } from 'path';
 import * as readline from 'readline/promises';
 import fs from 'fs';
@@ -31,6 +31,21 @@ program.opts().fhirUrl = program.opts().fhirUrl.replace(/\/*$/, '/');
 // get absolute path for specified destination directory
 program.opts().destination = resolve(program.opts().destination);
 
+const validateInputs = (opts: OptionValues) => {
+  if (opts.tokenUrl || opts.cliendId || opts.privateKey) {
+    const missingInputs = [];
+    if (!opts.tokenUrl) missingInputs.push('Token URL');
+    if (!opts.clientId) missingInputs.push('Client ID');
+    if (!opts.privateKey) missingInputs.push('Private Key');
+
+    if (missingInputs.length > 0) {
+      throw new Error(
+        `Token URL, Client ID, and Private Key must all be provided or all omitted. Missing ${missingInputs.join(', ')}`
+      );
+    }
+  }
+};
+
 const main = async () => {
   const requests = {
     https: {
@@ -42,6 +57,8 @@ const main = async () => {
       // pass custom headers
     },
   };
+
+  validateInputs(program.opts());
 
   if (program.opts().privateKey) {
     program.opts().privateKey = await resolveJWK(program.opts().privateKey);

--- a/src/jwk.ts
+++ b/src/jwk.ts
@@ -1,0 +1,36 @@
+import * as jose from 'jose';
+import { readFile } from 'fs/promises';
+import * as path from 'path';
+import * as http from 'http';
+
+export const resolveJWK = (keyLocation: string): Promise<jose.JWK.Key> => {
+  if (keyLocation.startsWith('http://') || keyLocation.startsWith('https://')) {
+    return loadJWKFromURL(keyLocation);
+  } else {
+    return loadJWKFromFile(keyLocation);
+  }
+};
+
+const loadJWKFromFile = async (filename: string): Promise<jose.JWK.Key> => {
+  const jwk = await readFile(path.join(process.cwd(), filename), 'utf-8');
+  const jwky = jose.JWK.asKey(JSON.parse(jwk));
+  jwky.toPEM();
+  return jwky;
+};
+
+
+const loadJWKFromURL = async (url: string): Promise<jose.JWK.Key> => {
+  const promise = new Promise<jose.JWK.Key>((resolve) => {
+    http.get(url, (res) => {
+      res.setEncoding('utf8');
+      let rawData = '';
+      res.on('data', (chunk) => {
+        rawData += chunk;
+      });
+      res.on('end', () => {
+        resolve(jose.JWK.asKey(JSON.parse(rawData)));
+      });
+    });
+  });
+  return promise;
+};

--- a/src/jwk.ts
+++ b/src/jwk.ts
@@ -1,7 +1,6 @@
 import * as jose from 'jose';
 import { readFile } from 'fs/promises';
 import * as path from 'path';
-import * as http from 'http';
 
 export const resolveJWK = async (keyLocation: string): Promise<jose.JWK.Key> => {
   const jwk = await readFile(path.join(process.cwd(), keyLocation), 'utf-8');
@@ -9,4 +8,3 @@ export const resolveJWK = async (keyLocation: string): Promise<jose.JWK.Key> => 
   jwk_key.toPEM();
   return jwk_key;
 };
-

--- a/src/jwk.ts
+++ b/src/jwk.ts
@@ -3,34 +3,10 @@ import { readFile } from 'fs/promises';
 import * as path from 'path';
 import * as http from 'http';
 
-export const resolveJWK = (keyLocation: string): Promise<jose.JWK.Key> => {
-  if (keyLocation.startsWith('http://') || keyLocation.startsWith('https://')) {
-    return loadJWKFromURL(keyLocation);
-  } else {
-    return loadJWKFromFile(keyLocation);
-  }
+export const resolveJWK = async (keyLocation: string): Promise<jose.JWK.Key> => {
+  const jwk = await readFile(path.join(process.cwd(), keyLocation), 'utf-8');
+  const jwk_key = jose.JWK.asKey(JSON.parse(jwk));
+  jwk_key.toPEM();
+  return jwk_key;
 };
 
-const loadJWKFromFile = async (filename: string): Promise<jose.JWK.Key> => {
-  const jwk = await readFile(path.join(process.cwd(), filename), 'utf-8');
-  const jwky = jose.JWK.asKey(JSON.parse(jwk));
-  jwky.toPEM();
-  return jwky;
-};
-
-
-const loadJWKFromURL = async (url: string): Promise<jose.JWK.Key> => {
-  const promise = new Promise<jose.JWK.Key>((resolve) => {
-    http.get(url, (res) => {
-      res.setEncoding('utf8');
-      let rawData = '';
-      res.on('data', (chunk) => {
-        rawData += chunk;
-      });
-      res.on('end', () => {
-        resolve(jose.JWK.asKey(JSON.parse(rawData)));
-      });
-    });
-  });
-  return promise;
-};

--- a/src/jwk.ts
+++ b/src/jwk.ts
@@ -1,10 +1,9 @@
-import * as jose from 'jose';
+import * as jose from 'node-jose';
 import { readFile } from 'fs/promises';
 import * as path from 'path';
 
 export const resolveJWK = async (keyLocation: string): Promise<jose.JWK.Key> => {
   const jwk = await readFile(path.join(process.cwd(), keyLocation), 'utf-8');
-  const jwk_key = jose.JWK.asKey(JSON.parse(jwk));
-  jwk_key.toPEM();
+  const jwk_key = jose.JWK.asKey(jwk, 'json');
   return jwk_key;
 };


### PR DESCRIPTION
# Summary

Enables interaction with secured bulk data servers using [SMART Backend Services](http://www.hl7.org/fhir/smart-app-launch/backend-services.html).

_Note: This PR is based off https://github.com/bulk-dqm/bulk-data-export-client/pull/2_
_Note: This PR also updates the bulk-client dependency to address https://github.com/smart-on-fhir/bulk-data-client/issues/10_

## Motivation

Bulk Data Systems use SMART Backend Services for authorization and authentication. This PR enables the bulk-data-export-client to interact with these secured systems.

[Paragraph (g)(10)(v)(B)](https://www.healthit.gov/test-method/standardized-api-patient-and-population-services)
>  Authentication and authorization must occur during the process of granting an application access to patient data in accordance with the “SMART Backend Services: Authorization Guide”

## New Behaviors

Users may provide a token URL, client ID, and location of a private key file to complete the authorization handshake and retrieve the bulk data resources requested.

## Code Changes

* New flags:
  * ﻿﻿`--token-url <tokenUrl> Bulk Token Authorization Endpoint`
  * `--client-id <clientId> Bulk Data Client ID`
  * `--private-key <url> File containing private key used to sign authentication tokens`
* Updates `bulk-client` dependency to a version which addresses https://github.com/smart-on-fhir/bulk-data-client/issues/10
* Adds a new function for extracting the private key from the file. (Providing the JWK as a string is not sufficient as it causes the underlying josev2.0.0 library to recognize the key as symmetric.

# Testing Guidance

I tested against the secured [inferno-reference server](https://inferno.healthit.gov/reference-server) and the unsecured SMART BCH test server.

To test against the inferno reference server:
* Extract one of the [test signing key](https://github.com/onc-healthit/onc-certification-g10-test-kit/blob/5c81c5f323eb07d94db4eef6c3544048608cff66/lib/onc_certification_g10_test_kit/bulk_data_jwks.json#L16-L28)s into it's own file in this repo (e.g., `inferno_es384_jwks.json`)
* Run the following:
```sh
npm run cli -- -f https://inferno.healthit.gov/reference-server/r4 -g 1a --token-url https://inferno.healthit.gov/reference-server/oauth/bulk-token --client-id eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InJlZ2lzdHJhdGlvbi10b2tlbiJ9.eyJqd2tzX3VybCI6Imh0dHA6Ly8xMC4xNS4yNTIuNzMvaW5mZXJuby8ud2VsbC1rbm93bi9qd2tzLmpzb24iLCJhY2Nlc3NUb2tlbnNFeHBpcmVJbiI6MTUsImlhdCI6MTU5NzQxMzE5NX0.q4v4Msc74kN506KTZ0q_minyapJw0gwlT6M_uiL73S4 --private-key ./inferno_es384_jwks.json
```

To test against the SMART BCH test server to ensure there are no regressions for unsecured servers try:
```sh
npm run cli -- -f https://bulk-data.smarthealthit.org/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1IjozLCJkZWwiOjB9/fhir -g 048d4683-703a-4311-963d-48e515a6372b
```