### PR TITLE
Update duration to be in seconds

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -176,7 +176,7 @@ const main = async () => {
       resources: 0,
       bytes: 0,
       attachments: 0,
-      duration: Date.now() - startTime,
+      duration: (Date.now() - startTime) / 1000,
     };
 
     downloads.forEach((d) => {


### PR DESCRIPTION
The `duration` is used in the generated export report to indicate how long the export took. The duration is currently reported in milliseconds but falsely labeled as "seconds" in the HTML report. This PR makes the conversion from milliseconds to seconds so that the report accurately reports the number of seconds the operation took.