### PR TITLE
Add script for generating report from logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "prettier:fix": "prettier --write \"**/*.{js,ts}\"",
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "parse-compartment-definition": "ts-node ./scripts/parseCompartmentDefinition.js"
+    "parse-compartment-definition": "ts-node ./scripts/parseCompartmentDefinition.js",
+    "generate-report": "ts-node ./scripts/createReportFromLogs.ts"
   },
   "repository": {
     "type": "git",

--- a/scripts/createReportFromLogs.ts
+++ b/scripts/createReportFromLogs.ts
@@ -1,0 +1,16 @@
+import { createExportReport } from '../src/reportGenerator';
+import { resolve } from 'path';
+import fs from 'fs';
+
+const logFile = process.argv[2];
+const destination = process.argv[3] || process.cwd();
+
+console.log(`Generating export report for ${logFile} and saving to the ${destination} directory...`);
+if (!fs.existsSync(destination)) {
+  fs.mkdirSync(destination, { recursive: true });
+}
+createExportReport(resolve(logFile), destination)
+  .then(() => {
+    console.log(`Successfully generated export report for log file ${logFile}`);
+  })
+  .catch(console.error);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -137,7 +137,7 @@ const executeExport = async () => {
   const statusEndpoint = await client.kickOff();
   const manifest = await client.waitForExport(statusEndpoint);
   await client.downloadAllFiles(manifest);
-  await createExportReport(options.destination, logFile);
+  await createExportReport(logFile, options.destination);
 };
 
 /**

--- a/src/reportGenerator.ts
+++ b/src/reportGenerator.ts
@@ -2,10 +2,10 @@ import { readFile, writeFile } from 'fs/promises';
 
 /**
  * Generates html export report from data collected throughout bulk export operation
- * @param downloadDir download directory from CLI options
  * @param file ndjson log file containing bulk export results
+ * @param downloadDir download directory from CLI options
  */
-export const createExportReport = async (downloadDir: string, file: string) => {
+export const createExportReport = async (file: string, downloadDir: string) => {
   const data = await readFile(file, 'utf8');
   const jsonLogs = data
     .split('\n')


### PR DESCRIPTION
# Summary
Adds `npm` script that generates reports based on an available `log.ndjson` file. This allows us to generate reports after an export has finished.

# Testing Guidance
Run the following `npm` command: `npm run generate-report <log file> <destination>`. The `<destination>` argument is optional - if not provided, the report will be written to the current working directory.

Test with some of the log files generated from the Connectathon. Note that the Connectathon reports will not have results for the number of polling requests (status progress logs were not implemented during the Jan. Connectathon), so the number of requests will be reported as zero.