### PR TITLE
add CLI option for _type

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The supported options for making a request to a FHIR server are as follows:
 -o, --output-path <path> Output path for FHIR MeasureReports produced from measure evaluation. Defaults to output.json
 --reporter [cli|text] Reporter to use to render the output. "cli" renders fancy progress bars and tables. "text" is better for log files. Defaults to "cli".
 --lenient Sets a "Prefer: handling=lenient" request header to tell the server to ignore unsupported parameters.
+-t, --_type <resourceTypes> String of comma-delimited FHIR resource types. If omitted, exports resources of all resource types.
 --config <path> Relative path to a config file. Otherwise uses default options.
 ```
 ## License

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,6 +55,10 @@ program
     '--lenient',
     'Sets a "Prefer: handling=lenient" request header to tell the server to ignore unsupported parameters.'
   )
+  .option(
+    '-t, --_type <resourceTypes>',
+    'String of comma-delimited FHIR resource types. If omitted, exports resources of all resource types.'
+  )
   .option('--config <path>', 'Relative path to a config file. Otherwise uses default options.')
   .parseAsync(process.argv);
 


### PR DESCRIPTION
# Summary
This PR adds a CLI option for the `_type` $export parameter, which is defined in the [Bulk Data Access IG](https://build.fhir.org/ig/HL7/bulk-data/export.html). The parameter takes in a string of comma-delimited FHIR resource types (examples: `_type=Patient` to restrict to just patients, `_type=Patient,Observation` to restrict to both Patient and Observation resources). When supplied, the underlying SMART BCH client appends the `_type` parameter to the supplied FHIR Url used for `$export`. (The supplied parameter(s) will also appear on the export URL that is included in the generated HTML report).

# Testing Guidance
Servers that support `_type`:
* [Epic](https://fhir.epic.com/)  
* [SMART test server](https://bulk-data.smarthealthit.org/) 
* [Abacus Bulk Export Server](https://github.com/projecttacoma/bulk-export-server)

Test the use of the `_type` parameter with each of these servers, and take note of the filtered ndjson that gets returned.

## Example test commands:
SMART test server: 
```bash
npm run cli -- -f https://bulk-data.smarthealthit.org/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1IjozLCJkZWwiOjB9/fhir -g 4017035f-681e-4e5a-9ac3-4a27c7aa57dd -m proportion-boolean-bundle.json -t Patient,Observation
```

Abacus Bulk Export Server (assuming it is running locally on port 3001):
```bash
npm run cli -- -f http://localhost:3001 -g DiabetesHemoglobinA1cHbA1cPoorControl9FHIR-patients -m proportion-boolean-bundle.json -t Patient,Condition
```
