### PR TITLE
Expose _since parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The supported options for making a request to a FHIR server are as follows:
 --reporter [cli|text] Reporter to use to render the output. "cli" renders fancy progress bars and tables. "text" is better for log files. Defaults to "cli".
 --lenient Sets a "Prefer: handling=lenient" request header to tell the server to ignore unsupported parameters.
 -t, --_type <resourceTypes> String of comma-delimited FHIR resource types. If omitted, exports resources of all resource types.
+-s, --_since <date> Only include resources modified after the specified date. The parameter can be provided as a partial date.
 --config <path> Relative path to a config file. Otherwise uses default options.
 ```
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -60,6 +60,7 @@ program
     '-t, --_type <resourceTypes>',
     'String of comma-delimited FHIR resource types. If omitted, exports resources of all resource types.'
   )
+  .option('-s, --_since <date>', 'Only include resources modified after the specified date.')
   .option('--config <path>', 'Relative path to a config file. Otherwise uses default options.')
   .parseAsync(process.argv);
 


### PR DESCRIPTION
# Overview
This PR exposes a CLI option for the `_since` parameter. In short, the parameter only exports resources modified after the specified date.

## Details
The `_since` parameter’s type is technically a FHIR instant, which is an instant in time in the format YYYY-MM-DDThh:mm:ss.sss+zz:zz (essentially a more constrained dateTime). However, the BCH client uses Moment to do parsing, and so partial dates can be provided via the CLI and they will be appropriately converted to the FHIR instant type.

Some server-side notes that we might want to keep in mind as we do more testing:
* In the case of Group-level export, the server MAY return additional resources modified prior to the supplied time if the resources belong to the patient compartment of a patient added to the Group after the supplied time
* For Group-level export, the server MAY return resources that are referenced by the resources being returned, regardless of when the referenced resources were last updated
* For resources where the server does not maintain a last updated time (via `Resource.meta.lastUpdated`), the server MAY include these resources in a response irrespective of the `_since` value supplied by a client

## Testing Guidance
Test in the BCH server with and without the `_since` parameter. Here are some of my results:

1. Testing without `_since`:

```
npm run cli -- -f https://bulk-data.smarthealthit.org/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1IjozLCJkZWwiOjB9/fhir -g 4017035f-681e-4e5a-9ac3-4a27c7aa57dd
```
Results: 4336 FHIR resources

2. Testing with `-s 2017-01-01T00:00:00Z`:
```
npm run cli -- -f https://bulk-data.smarthealthit.org/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1IjozLCJkZWwiOjB9/fhir -g 4017035f-681e-4e5a-9ac3-4a27c7aa57dd -s 2017-01-01T00:00:00Z
```
Results: 1200 FHIR resources

3. Testing with `-s 2017` (to check that partial dates are sufficient in the client):

```
npm run cli -- -f https://bulk-data.smarthealthit.org/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1IjozLCJkZWwiOjB9/fhir -g 4017035f-681e-4e5a-9ac3-4a27c7aa57dd -s 2017
```
Results: Also 1200 FHIR resources (what we should expect)