### PR TITLE
Upgrade fqm-execution, change report type to summary

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "bulk-data-client": "git+https://git@github.com/smart-on-fhir/bulk-data-client",
         "colors": "^1.4.0",
         "commander": "^9.4.1",
-        "fqm-execution": "^1.0.1",
+        "fqm-execution": "^1.0.8",
         "node-jose": "^2.0.0",
         "ts-node": "^10.9.1",
         "ts-node-dev": "^2.0.0"
@@ -4236,12 +4236,13 @@
       }
     },
     "node_modules/cql-execution": {
-      "version": "3.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.2.tgz",
-      "integrity": "sha512-rpBUkUotVAUfz73HGF+Vs1UItULuZcEGmAwHkPxCpWEUXXVKWL7Dc9vPbRu5lCteMovKSJDSZsK+jHqDd+iYhQ==",
+      "version": "3.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.4.tgz",
+      "integrity": "sha512-TWAVtdZEr0h/P7CXRV+DBdPRdougBkG30AgXg/N8Xz4upbmc4zNTg2cfAAvMbJrsYl5sqZbJFcUvxaGcTZGjqw==",
       "dependencies": {
         "@lhncbc/ucum-lhc": "^4.1.3",
-        "luxon": "^1.25.0"
+        "immutable": "^4.1.0",
+        "luxon": "^1.28.1"
       }
     },
     "node_modules/create-require": {
@@ -5419,16 +5420,16 @@
       }
     },
     "node_modules/fqm-execution": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-1.0.3.tgz",
-      "integrity": "sha512-oCpLogf7Kq8i+xHTEVyhxjD1rnCnbvShr6zFx+xW1oDaBdeH0aAGHvkY856vETBqJyoAT32jjoF7Hvpsf5ZLgg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-1.0.8.tgz",
+      "integrity": "sha512-psG7H9LyugdUz+5w3yrKxtYkS/uFEaWU880enJIPJT2aiax8mS7d+OIJ9YVfHH3ZfSYqwO6reSuzUnahi4HDbw==",
       "dependencies": {
         "@types/fhir": "0.0.34",
         "atob": "^2.1.2",
         "axios": "^0.21.1",
         "commander": "^6.1.0",
         "cql-exec-fhir": "^2.1.3",
-        "cql-execution": "^3.0.0-beta.2",
+        "cql-execution": "^3.0.0-beta.3",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
@@ -5901,6 +5902,11 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immutable": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
+      "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg=="
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -13118,12 +13124,13 @@
       }
     },
     "cql-execution": {
-      "version": "3.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.2.tgz",
-      "integrity": "sha512-rpBUkUotVAUfz73HGF+Vs1UItULuZcEGmAwHkPxCpWEUXXVKWL7Dc9vPbRu5lCteMovKSJDSZsK+jHqDd+iYhQ==",
+      "version": "3.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/cql-execution/-/cql-execution-3.0.0-beta.4.tgz",
+      "integrity": "sha512-TWAVtdZEr0h/P7CXRV+DBdPRdougBkG30AgXg/N8Xz4upbmc4zNTg2cfAAvMbJrsYl5sqZbJFcUvxaGcTZGjqw==",
       "requires": {
         "@lhncbc/ucum-lhc": "^4.1.3",
-        "luxon": "^1.25.0"
+        "immutable": "^4.1.0",
+        "luxon": "^1.28.1"
       }
     },
     "create-require": {
@@ -13998,16 +14005,16 @@
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
     },
     "fqm-execution": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-1.0.3.tgz",
-      "integrity": "sha512-oCpLogf7Kq8i+xHTEVyhxjD1rnCnbvShr6zFx+xW1oDaBdeH0aAGHvkY856vETBqJyoAT32jjoF7Hvpsf5ZLgg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/fqm-execution/-/fqm-execution-1.0.8.tgz",
+      "integrity": "sha512-psG7H9LyugdUz+5w3yrKxtYkS/uFEaWU880enJIPJT2aiax8mS7d+OIJ9YVfHH3ZfSYqwO6reSuzUnahi4HDbw==",
       "requires": {
         "@types/fhir": "0.0.34",
         "atob": "^2.1.2",
         "axios": "^0.21.1",
         "commander": "^6.1.0",
         "cql-exec-fhir": "^2.1.3",
-        "cql-execution": "^3.0.0-beta.2",
+        "cql-execution": "^3.0.0-beta.3",
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
@@ -14352,6 +14359,11 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
       "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true
+    },
+    "immutable": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
+      "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg=="
     },
     "import-fresh": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "bulk-data-client": "git+https://git@github.com/smart-on-fhir/bulk-data-client",
     "colors": "^1.4.0",
     "commander": "^9.4.1",
-    "fqm-execution": "^1.0.1",
+    "fqm-execution": "^1.0.8",
     "ts-node": "^10.9.1",
     "ts-node-dev": "^2.0.0",
     "node-jose": "^2.0.0"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -177,7 +177,7 @@ const runMeasureCalculation = async () => {
   const calculationOptions: CalculatorTypes.CalculationOptions = {
     measurementPeriodStart: '2019-01-01',
     measurementPeriodEnd: '2019-12-31',
-    reportType: 'summary'
+    reportType: 'summary',
   };
   const measureBundle = await loadBundleFromFile(options.measureBundle);
   const patientBundles = await loadPatientBundlesFromDir(options.patientBundles ?? 'patientBundles');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -177,6 +177,7 @@ const runMeasureCalculation = async () => {
   const calculationOptions: CalculatorTypes.CalculationOptions = {
     measurementPeriodStart: '2019-01-01',
     measurementPeriodEnd: '2019-12-31',
+    reportType: 'summary'
   };
   const measureBundle = await loadBundleFromFile(options.measureBundle);
   const patientBundles = await loadPatientBundlesFromDir(options.patientBundles ?? 'patientBundles');


### PR DESCRIPTION
See https://github.com/projecttacoma/fqm-execution/releases for more context

Adds detailed error handling from cql-execution (helpful for identifying errors related to measure calculation for measure bundles that may have CQL errors)

This PR also changes measure calculation `reportType` to "summary" since we will be using this report type going forward