### PR TITLE
Expose _typeFilter parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The supported options for making a request to a FHIR server are as follows:
 --lenient Sets a "Prefer: handling=lenient" request header to tell the server to ignore unsupported parameters.
 -t, --_type <resourceTypes> String of comma-delimited FHIR resource types. If omitted, exports resources of all resource types.
 -s, --_since <date> Only include resources modified after the specified date. The parameter can be provided as a partial date.
+-q, --_typeFilter <string> Experimental _typeFilter parameter. Represents a string of comma delimited FHIR REST queries.
 --config <path> Relative path to a config file. Otherwise uses default options.
 ```
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -61,6 +61,10 @@ program
     'String of comma-delimited FHIR resource types. If omitted, exports resources of all resource types.'
   )
   .option('-s, --_since <date>', 'Only include resources modified after the specified date.')
+  .option(
+    '-q, --_typeFilter <string>',
+    'Experimental _typeFilter parameter. Represents a string of comma delimited FHIR REST queries.'
+  )
   .option('--config <path>', 'Relative path to a config file. Otherwise uses default options.')
   .parseAsync(process.argv);
 


### PR DESCRIPTION
Exposes `_typeFilter` param in the client.

Usage: use `-q` or `--_typeFilter` in the CLI

See the [documentation](https://build.fhir.org/ig/HL7/bulk-data/export.html#query-parameters) for details on the parameter.

Tested with the abacus export server, which has specific functionality for ValueSet-related queries (cannot do more generic queries).