### PR TITLE
Add Export timestamp to performance reports

### DIFF
--- a/src/fqm.ts
+++ b/src/fqm.ts
@@ -20,6 +20,7 @@ export const calculateMeasureReports = async (
   patientBundle: fhir4.Bundle[],
   options: CalculatorTypes.CalculationOptions = {}
 ) => {
+  console.log('Generating summary measure report...');
   return await Calculator.calculateMeasureReports(measureBundle, patientBundle, options);
 };
 

--- a/src/logEvents.ts
+++ b/src/logEvents.ts
@@ -48,7 +48,7 @@ export const setLoggingEvents = (logger: any, client: any) => {
         outputFileCount: manifest.output.length,
         deletedFileCount: manifest.deleted?.length || 0,
         errorFileCount: manifest.error?.length || 0,
-        duration: ((Date.now() - startTime) / 1000).toFixed(2),
+        duration: Date.now() - startTime,
       },
     });
   });
@@ -71,7 +71,7 @@ export const setLoggingEvents = (logger: any, client: any) => {
       resources: 0,
       bytes: 0,
       attachments: 0,
-      duration: ((Date.now() - startTime) / 1000).toFixed(2),
+      duration: Date.now() - startTime,
     };
 
     downloads.forEach((d) => {

--- a/src/logEvents.ts
+++ b/src/logEvents.ts
@@ -48,6 +48,7 @@ export const setLoggingEvents = (logger: any, client: any) => {
         outputFileCount: manifest.output.length,
         deletedFileCount: manifest.deleted?.length || 0,
         errorFileCount: manifest.error?.length || 0,
+        duration: ((Date.now() - startTime) / 1000).toFixed(2),
       },
     });
   });
@@ -70,7 +71,7 @@ export const setLoggingEvents = (logger: any, client: any) => {
       resources: 0,
       bytes: 0,
       attachments: 0,
-      duration: Date.now() - startTime,
+      duration: ((Date.now() - startTime) / 1000).toFixed(2),
     };
 
     downloads.forEach((d) => {

--- a/src/reportGenerator.ts
+++ b/src/reportGenerator.ts
@@ -18,7 +18,7 @@ export const createExportReport = async (file: string, downloadDir: string) => {
 
   // there should be one kickoff log and one export log, and at least one download log
   const kickoffResults = exportEvents.filter((log) => log.eventId === 'kickoff')[0];
-  const exportResults = exportEvents.filter((log) => log.eventId === 'status_complete')[0];
+  const statusCompleteResults = exportEvents.filter((log) => log.eventId === 'status_complete')[0];
   const exportCompleteResults = exportEvents.filter((log) => log.eventId === 'export_complete')[0];
   const downloadResults = exportEvents.filter((log) => log.eventId === 'download_complete');
   const numPollingRequests = exportEvents.filter((log) =>
@@ -38,9 +38,9 @@ export const createExportReport = async (file: string, downloadDir: string) => {
         <li>Files: ${exportCompleteResults.eventDetail.files}</li>
         <li>Resources: ${exportCompleteResults.eventDetail.resources}</li>
         <li> Total Duration: ${exportCompleteResults.eventDetail.duration} seconds</li>
-          <li> Export Duration: ${exportResults.eventDetail.duration} seconds</li>
+          <li> Export Duration: ${statusCompleteResults.eventDetail.duration} seconds</li>
           <li> Download Duration: ${(
-            exportCompleteResults.eventDetail.duration - exportResults.eventDetail.duration
+            exportCompleteResults.eventDetail.duration - statusCompleteResults.eventDetail.duration
           ).toFixed(2)} seconds</li>
       </ul>
       </p>

--- a/src/reportGenerator.ts
+++ b/src/reportGenerator.ts
@@ -37,11 +37,11 @@ export const createExportReport = async (file: string, downloadDir: string) => {
       <ul>
         <li>Files: ${exportCompleteResults.eventDetail.files}</li>
         <li>Resources: ${exportCompleteResults.eventDetail.resources}</li>
-        <li> Total Duration: ${exportCompleteResults.eventDetail.duration} seconds</li>
-          <li> Export Duration: ${statusCompleteResults.eventDetail.duration} seconds</li>
-          <li> Download Duration: ${(
+        <li> Total Duration: ${exportCompleteResults.eventDetail.duration} milliseconds</li>
+          <li> Export Duration: ${statusCompleteResults.eventDetail.duration} milliseconds</li>
+          <li> Download Duration: ${
             exportCompleteResults.eventDetail.duration - statusCompleteResults.eventDetail.duration
-          ).toFixed(2)} seconds</li>
+          } milliseconds</li>
       </ul>
       </p>
       <h2>Created Files:</h2>

--- a/src/reportGenerator.ts
+++ b/src/reportGenerator.ts
@@ -18,6 +18,7 @@ export const createExportReport = async (file: string, downloadDir: string) => {
 
   // there should be one kickoff log and one export log, and at least one download log
   const kickoffResults = exportEvents.filter((log) => log.eventId === 'kickoff')[0];
+  const exportResults = exportEvents.filter((log) => log.eventId === 'status_complete')[0];
   const exportCompleteResults = exportEvents.filter((log) => log.eventId === 'export_complete')[0];
   const downloadResults = exportEvents.filter((log) => log.eventId === 'download_complete');
   const numPollingRequests = exportEvents.filter((log) =>
@@ -36,7 +37,11 @@ export const createExportReport = async (file: string, downloadDir: string) => {
       <ul>
         <li>Files: ${exportCompleteResults.eventDetail.files}</li>
         <li>Resources: ${exportCompleteResults.eventDetail.resources}</li>
-        <li>Duration: ${exportCompleteResults.eventDetail.duration} seconds</li>
+        <li> Total Duration: ${exportCompleteResults.eventDetail.duration} seconds</li>
+          <li> Export Duration: ${exportResults.eventDetail.duration} seconds</li>
+          <li> Download Duration: ${(
+            exportCompleteResults.eventDetail.duration - exportResults.eventDetail.duration
+          ).toFixed(2)} seconds</li>
       </ul>
       </p>
       <h2>Created Files:</h2>


### PR DESCRIPTION
# Summary
- Adds a `duration` field to the log events that corresponds to the duration from start to completed export.
- Converts all `duration` fields to seconds (this change got lost in a previous commit due to rebasing)
- Adds three metrics to the HTML report: total duration, export duration, and download duration.

# Testing Guidance
Test across multiple groups. Check that the sum of the export duration and download duration add up to the total duration. Check that the report's "export duration" matches the CLI output for "Bulk data export completed in __ seconds." Check that the report's "download duration" matches the CLI output for "Download completed in __ seconds"

![export-results](https://user-images.githubusercontent.com/87094479/232796256-6bbebc8e-9dcb-410b-961f-3e1dd65d4de0.png)
