### PR TITLE
Craft _type query

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The supported options for making a request to a FHIR server are as follows:
 -t, --_type <resourceTypes> String of comma-delimited FHIR resource types. If omitted, exports resources of all resource types.
 -s, --_since <date> Only include resources modified after the specified date. The parameter can be provided as a partial date.
 -q, --_typeFilter <string> Experimental _typeFilter parameter. Represents a string of comma delimited FHIR REST queries.
+-a, --auto-populate-type <boolean> Automatically populates _type using data requirements from the measure bundle. Requires a measure bundle path to be supplied.
 --config <path> Relative path to a config file. Otherwise uses default options.
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The supported options for making a request to a FHIR server are as follows:
 -t, --_type <resourceTypes> String of comma-delimited FHIR resource types. If omitted, exports resources of all resource types.
 -s, --_since <date> Only include resources modified after the specified date. The parameter can be provided as a partial date.
 -q, --_typeFilter <string> Experimental _typeFilter parameter. Represents a string of comma delimited FHIR REST queries.
--a, --auto-populate-type <boolean> Automatically populates _type using data requirements from the measure bundle. Requires a measure bundle path to be supplied.
+-a, --auto-populate-type <boolean> Automatically populates _type using data requirements from the measure bundle. Requires a measure bundle path to be supplied. Overrides any input provided by the --_type flag.
 --config <path> Relative path to a config file. Otherwise uses default options.
 ```
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,7 +15,12 @@ import { createExportReport } from './reportGenerator';
 import { assemblePatientBundle, getNDJSONFromDir } from './ndjsonToBundle';
 import { writeFile } from 'fs';
 import { CalculatorTypes } from 'fqm-execution';
-import { calculateMeasureReports, loadBundleFromFile, loadPatientBundlesFromDir } from './fqm';
+import {
+  calculateMeasureReports,
+  loadBundleFromFile,
+  loadPatientBundlesFromDir,
+  retrieveTypeFromMeasureBundle,
+} from './fqm';
 import { setLoggingEvents } from './logEvents';
 
 interface NormalizedOptions extends Omit<Types.NormalizedOptions, 'privateKey'> {
@@ -24,6 +29,7 @@ interface NormalizedOptions extends Omit<Types.NormalizedOptions, 'privateKey'> 
   measureBundle: string;
   patientBundles: string;
   privateKey: any;
+  autoPopulateType: boolean;
 }
 
 const program = new Command();
@@ -64,6 +70,10 @@ program
   .option(
     '-q, --_typeFilter <string>',
     'Experimental _typeFilter parameter. Represents a string of comma delimited FHIR REST queries.'
+  )
+  .option(
+    '-a, --auto-populate-type',
+    'Automatically populates _type using data requirements from the measure bundle. Requires a measure bundle path to be supplied.'
   )
   .option('--config <path>', 'Relative path to a config file. Otherwise uses default options.')
   .parseAsync(process.argv);
@@ -130,6 +140,20 @@ const checkDestinationExists = async (destination: string) => {
 const executeExport = async () => {
   if (!options.destination) options.destination = `${process.cwd()}/downloads`;
   await checkDestinationExists(options.destination);
+
+  if (options.autoPopulateType) {
+    console.log('in fn');
+    if (!options.measureBundle) {
+      console.log(
+        '--auto-populate-type supplied without a measure bundle. Measure bundle path must be supplied with the -m/--measure-bundle flag in order to automatically populate the _type parameter.'
+      );
+      program.help();
+    }
+    const mb = await loadBundleFromFile(options.measureBundle);
+    // override current value of _type with query from data requirements
+    options._type = await retrieveTypeFromMeasureBundle(mb);
+  }
+
   const client = new BulkDataClient(options as NormalizedOptions);
   if (options.reporter === 'text') {
     TextReporter(client);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -73,7 +73,7 @@ program
   )
   .option(
     '-a, --auto-populate-type',
-    'Automatically populates _type using data requirements from the measure bundle. Requires a measure bundle path to be supplied.'
+    'Automatically populates _type using data requirements from the measure bundle. Requires a measure bundle path to be supplied. Overrides any input provided by the --_type flag.'
   )
   .option('--config <path>', 'Relative path to a config file. Otherwise uses default options.')
   .parseAsync(process.argv);
@@ -142,7 +142,6 @@ const executeExport = async () => {
   await checkDestinationExists(options.destination);
 
   if (options.autoPopulateType) {
-    console.log('in fn');
     if (!options.measureBundle) {
       console.log(
         '--auto-populate-type supplied without a measure bundle. Measure bundle path must be supplied with the -m/--measure-bundle flag in order to automatically populate the _type parameter.'

--- a/src/fqm.test.ts
+++ b/src/fqm.test.ts
@@ -104,6 +104,7 @@ describe('retrieveTypeFromMeasureBundle', () => {
     expect(drSpy.mock.calls.length).toBe(1);
   });
 });
+
 describe('constructTypeQueryFromRequirements', () => {
   test('generates _type query for a single resource type', () => {
     expect(constructTypeQueryFromRequirements([{ type: 'Patient' }])).toEqual('Patient');

--- a/src/fqm.test.ts
+++ b/src/fqm.test.ts
@@ -1,4 +1,4 @@
-import { calculateMeasureReports, loadBundleFromFile, CalculatorTypes } from './fqm';
+import { calculateMeasureReports, loadBundleFromFile, CalculatorTypes, constructTypeQueryFromRequirements } from './fqm';
 
 describe('loadBundleFromFile', () => {
   describe('given a Measure file that exists', () => {
@@ -70,5 +70,35 @@ describe('calculateMeasureReports', () => {
     } else {
       fail('MeasureReport for IPP was not found');
     }
+  });
+});
+
+describe('constructTypeQueryFromRequirements', () => {
+  test('generates _type query for a single resource type', () => {
+    expect(constructTypeQueryFromRequirements([{type: 'Patient'}])).toEqual('Patient');
+  });
+
+  test('generates _type query for multiple resource types', () => {
+    const MULTIPLE_DR: fhir4.DataRequirement[] = [
+      {
+        type: 'Procedure',
+        codeFilter: [
+          {
+            path: 'type',
+            valueSet: 'TEST_VALUE_SET'
+          }
+        ]
+      },
+      {
+        type: 'Encounter',
+        codeFilter: [
+          {
+            path: 'code',
+            valueSet: 'TEST_VALUE_SET'
+          }
+        ]
+      }
+    ];
+    expect(constructTypeQueryFromRequirements(MULTIPLE_DR)).toEqual('Procedure,Encounter');
   });
 });

--- a/src/fqm.ts
+++ b/src/fqm.ts
@@ -1,6 +1,5 @@
 import { readFile, readdir } from 'fs/promises';
 import { Calculator, CalculatorTypes } from 'fqm-execution';
-import { DataRequirementsQuery } from './types/DataRequirementsQuery';
 import * as path from 'path';
 
 export const loadBundleFromFile = async (filename: string): Promise<fhir4.Bundle> => {
@@ -50,26 +49,18 @@ export const retrieveTypeFromMeasureBundle = async (
  * @param dataRequirements data requirements retrieved from measure bundle
  */
 export const constructTypeQueryFromRequirements = (dataRequirements: fhir4.DataRequirement[]) => {
-  const queries: DataRequirementsQuery[] = [];
+  const types: string[] = [];
 
   dataRequirements.forEach((dr) => {
     if (dr.type) {
-      const q: DataRequirementsQuery = { endpoint: dr.type, params: {} };
-      if (dr.codeFilter?.[0]?.code?.[0].code) {
-        const key = dr.codeFilter?.[0].path;
-        key && (q.params[key] = dr.codeFilter[0].code[0].code);
-      } else if (dr.codeFilter?.[0]?.valueSet) {
-        const key = `${dr?.codeFilter?.[0].path}:in`;
-        key && (q.params[key] = dr.codeFilter[0].valueSet);
-      }
-      queries.push(q);
+      types.push(dr.type);
     }
   });
 
   // reduce queries to keep unique types
-  const uniqueTypes = queries.reduce((acc: string[], e) => {
-    if (!acc.includes(e.endpoint)) {
-      acc.push(e.endpoint);
+  const uniqueTypes = types.reduce((acc: string[], type) => {
+    if (!acc.includes(type)) {
+      acc.push(type);
     }
     return acc;
   }, []);

--- a/src/fqm.ts
+++ b/src/fqm.ts
@@ -1,5 +1,6 @@
 import { readFile, readdir } from 'fs/promises';
 import { Calculator, CalculatorTypes } from 'fqm-execution';
+import { DataRequirementsQuery } from './types/DataRequirementsQuery';
 import * as path from 'path';
 
 export const loadBundleFromFile = async (filename: string): Promise<fhir4.Bundle> => {
@@ -22,6 +23,61 @@ export const calculateMeasureReports = async (
 ) => {
   console.log('Generating summary measure report...');
   return await Calculator.calculateMeasureReports(measureBundle, patientBundle, options);
+};
+
+/**
+ * Populates the _type parameter used in a bulk data export request. Retrieves the data
+ * requirements for the given measure bundle using the fqm-execution API function. Extracts
+ * the resource types from the data requirements. Throws error if data requirements are not
+ * defined on the results of the API function.
+ * @param measureBundle FHIR measure bundle
+ * @param options fqm-execution calculation options
+ */
+export const retrieveTypeFromMeasureBundle = async (
+  measureBundle: fhir4.Bundle,
+  options: CalculatorTypes.CalculationOptions = {}
+) => {
+  const dr = await Calculator.calculateDataRequirements(measureBundle, options);
+  if (!dr.results.dataRequirement) {
+    throw new Error('Data requirements array is not defined for the Library. Aborting $export request.');
+  }
+  return constructTypeQueryFromRequirements(dr.results.dataRequirement);
+};
+
+/**
+ * Constructs the _type parameter used in a bulk data export request by parsing the 
+ * data requirements for the measure bundle.
+ * @param dataRequirements data requirements retrieved from measure bundle
+ */
+export const constructTypeQueryFromRequirements = (
+  dataRequirements: fhir4.DataRequirement[]
+) => {
+  const queries: DataRequirementsQuery[] = [];
+
+  dataRequirements.forEach(dr => {
+    if (dr.type) {
+      const q: DataRequirementsQuery = { endpoint: dr.type, params: {}};
+      if (dr.codeFilter?.[0]?.code?.[0].code) {
+        const key = dr.codeFilter?.[0].path;
+        key && (q.params[key] = dr.codeFilter[0].code[0].code);
+      } else if (dr.codeFilter?.[0]?.valueSet) {
+        const key = `${dr?.codeFilter?.[0].path}:in`;
+        key && (q.params[key] = dr.codeFilter[0].valueSet);
+      }
+      queries.push(q);
+    }
+  });
+
+  // reduce queries to keep unique types
+  const uniqueTypes = queries.reduce((acc: string[], e) => {
+    if (!acc.includes(e.endpoint)) {
+      acc.push(e.endpoint);
+    }
+    return acc;
+  }, []);
+
+  const formattedTypeParam = uniqueTypes.join(',');
+  return formattedTypeParam;
 };
 
 export { CalculatorTypes } from 'fqm-execution';

--- a/src/fqm.ts
+++ b/src/fqm.ts
@@ -45,18 +45,16 @@ export const retrieveTypeFromMeasureBundle = async (
 };
 
 /**
- * Constructs the _type parameter used in a bulk data export request by parsing the 
+ * Constructs the _type parameter used in a bulk data export request by parsing the
  * data requirements for the measure bundle.
  * @param dataRequirements data requirements retrieved from measure bundle
  */
-export const constructTypeQueryFromRequirements = (
-  dataRequirements: fhir4.DataRequirement[]
-) => {
+export const constructTypeQueryFromRequirements = (dataRequirements: fhir4.DataRequirement[]) => {
   const queries: DataRequirementsQuery[] = [];
 
-  dataRequirements.forEach(dr => {
+  dataRequirements.forEach((dr) => {
     if (dr.type) {
-      const q: DataRequirementsQuery = { endpoint: dr.type, params: {}};
+      const q: DataRequirementsQuery = { endpoint: dr.type, params: {} };
       if (dr.codeFilter?.[0]?.code?.[0].code) {
         const key = dr.codeFilter?.[0].path;
         key && (q.params[key] = dr.codeFilter[0].code[0].code);


### PR DESCRIPTION
# Summary
When the `—auto-populate-type` flag is specified, the `_type` parameter will be populated using the data requirements of the passed-in measure bundle.

## Code Changes
* src/cli.ts - new boolean CLI flag `-a/--auto-populate-type` which signals that the client should check for the presence of a measure bundle, calculate its data requirements, and use the types on the data requirements for populating the `_type` parameter
* src/fqm.ts - Two new functions - one acts as a wrapper to calculate data requirements and pass the results to a second function that builds the comma-delimited `_type` string
* src/fqm.test.ts - new unit tests for the new functions

## Testing Guidance
* Run unit tests
* Test against multiple servers and multiple measures.
    * Test without the new `-a` flag to ensure existing functionality has not changed
    * Test with the new `-a` flag (and with the `-m` flag specified) and check the results in the export report to see which resource types were extracted from the data requirements
        * NOTE: it could be the case that the server returns a 400 when using this flag. This would occur if the server throws a 400 error for a type that is not supported by the server (for example, the SMART BCH server throws a 400 BadRequest error if any of the types in the comma-delimited string are not present on the server. I think all the other open-source servers just ignore types that are not present on the server)
    * Test with the new `-a` flag without the `-m` flag specified - this should bring up `program.help()` because a measure bundle is needed for calculating data requirements
    * Test with `-a` and `--_type` and make sure that the contents of the `--_type` param are not present on the export URL that is used for kickoff

## Open Questions
* Should we add any additional warnings to the user about the `_type` override when the `-a` flag is used?
* When we use the data requirements for populating `_type`, a measure bundle is specified, and so measure calculation is run every time because of the 3-step CLI that we set up a while back. Is this okay? Alternatively, we could add a `—no-measure-calculation` flag or something similar, but we have a lot of CLI flags as-is right now and I am not sure how often it would really be used (I’m more so thinking of the situations where we use very large groups and feed them through measure calculation, but in my experience the calculation did not take too long)