### PR TITLE
Add documentation on bulk data flow, advanced technical features

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ CLI application for FHIR Bulk Data Export and FHIR-based quality measure calcula
 - [Dependent Open-Source Libraries](#dependent-open-source-libraries)
   - [FHIR Quality Measure (FQM) Execution](#fhir-quality-measure-fqm-execution)
   - [SMART on FHIR Bulk Data Client](#smart-on-fhir-bulk-data-client)
+- [Bulk Data Implementation](#bulk-data-implementation)
 - [API Reference](#api-reference)
 - [Advanced Topics](#advanced-topics)
 - [Documentation Resources](#documentation-resources)

--- a/README.md
+++ b/README.md
@@ -265,6 +265,9 @@ The SMART on FHIR `bulk-data-client` open source application provides the core B
 
 `@types/fhir` is available on [npm](https://www.npmjs.com/package/@types/fhir).
 
+## Bulk Data Implementation
+For more information on the supported Bulk Data Export endpoints, the request flow, and authorization, see [the Bulk Data Implementation documentation](/docs/bulk-data.md).
+
 ## API Reference
 See [the API Reference](/docs/api-reference.md)
 

--- a/docs/advanced-topics.md
+++ b/docs/advanced-topics.md
@@ -13,14 +13,14 @@ The client uses the [FHIR Patient Compartment Definition](http://hl7.org/fhir/R4
 4. Writes the collection bundles to the `patientBundles` directory or the user-specified patient bundles directory.
 
 ## Automatic `--_type` Population
-The client can (optionally) automatically populate the `_type` parameter using a given FHIR Measure's data requirements.
+Optionally, the client can automatically populate the `_type` parameter using the data requirements of a provided FHIR Measure.
 
-To automatically populate the `_type` parameter prior to sending a Bulk Data Export kick-off request using the CLI, the `--auto-populate-type` flag must be specified, and a measure bundle path must also be specified. When present, the data requirements output will override any input provided by the `--_type` flag.
+To automatically populate the `_type` parameter prior to sending a Bulk Data Export kick-off request, the `--auto-populate-type` CLI flag must be specified, and a measure bundle path must also be specified. When present, the data requirements output will override any input provided by the `--_type` flag.
 
 The client retrieves the data requirements for the given measure using the [fqm-execution](https://github.com/projecttacoma/fqm-execution) `calculateDataRequirements` API function, and then extracts the `type`s from each data requirement that gets returned from the API function.
 
 ## Measure Report Generation
-When a path to a measure bundle is specified, measure calculation is run against all the patients that are members of the FHIR Group used for Group Export. The client uses the [fqm-execution](https://github.com/projecttacoma/fqm-execution) `calculateMeasureReports` API function to generate a FHIR MeasureReport of type `summary` that contains a measure score across all the patients.
+When a path to a measure bundle is specified, the application runs measure calculation against all the patients that are members of the FHIR Group used for Group Export. The client uses the [fqm-execution](https://github.com/projecttacoma/fqm-execution) `calculateMeasureReports` API function to generate a FHIR MeasureReport of type `summary` that contains a measure score across all the patients.
 
 ## Export Report Generation
 Upon successful export and download, an HTML report is generated for the completed export requests. This report is generated in the downloads directory and contains data about the export like the URL, the number of polling requests, the number of downloaded files and resources, and the export and download durations.

--- a/docs/advanced-topics.md
+++ b/docs/advanced-topics.md
@@ -11,3 +11,10 @@ The client uses the [FHIR Patient Compartment Definition](http://hl7.org/fhir/R4
 
 3. For each patient, constructs a FHIR Collection Bundle containing the FHIR Patient resource and all downloaded resources that reference the patient.
 4. Writes the collection bundles to the `patientBundles` directory or the user-specified patient bundles directory.
+
+## Automatic `--_type` Population
+The client can (optionally) automatically populate the `_type` parameter using a given FHIR Measure's data requirements.
+
+To automatically populate the `_type` parameter prior to sending a Bulk Data Export kick-off request using the CLI, the `--auto-populate-type` flag must be specified, and a measure bundle path must also be specified. When present, the data requirements output will override any input provided by the `--_type` flag.
+
+The client retrieves the data requirements for the given measure using the [fqm-execution](https://github.com/projecttacoma/fqm-execution) `calculateDataRequirements` API function, and then extracts the `type`s from each data requirement that gets returned from the API function.

--- a/docs/advanced-topics.md
+++ b/docs/advanced-topics.md
@@ -18,3 +18,6 @@ The client can (optionally) automatically populate the `_type` parameter using a
 To automatically populate the `_type` parameter prior to sending a Bulk Data Export kick-off request using the CLI, the `--auto-populate-type` flag must be specified, and a measure bundle path must also be specified. When present, the data requirements output will override any input provided by the `--_type` flag.
 
 The client retrieves the data requirements for the given measure using the [fqm-execution](https://github.com/projecttacoma/fqm-execution) `calculateDataRequirements` API function, and then extracts the `type`s from each data requirement that gets returned from the API function.
+
+## Measure Report Generation
+When a path to a measure bundle is specified, measure calculation is run against all the patients that are members of the FHIR Group used for Group Export. The client uses the [fqm-execution](https://github.com/projecttacoma/fqm-execution) `calculateMeasureReports` API function to generate a FHIR MeasureReport of type `summary` that contains a measure score across all the patients.

--- a/docs/advanced-topics.md
+++ b/docs/advanced-topics.md
@@ -21,3 +21,6 @@ The client retrieves the data requirements for the given measure using the [fqm-
 
 ## Measure Report Generation
 When a path to a measure bundle is specified, measure calculation is run against all the patients that are members of the FHIR Group used for Group Export. The client uses the [fqm-execution](https://github.com/projecttacoma/fqm-execution) `calculateMeasureReports` API function to generate a FHIR MeasureReport of type `summary` that contains a measure score across all the patients.
+
+## Export Report Generation
+Upon successful export and download, an HTML report is generated for the completed export requests. This report is generated in the downloads directory and contains data about the export like the URL, the number of polling requests, the number of downloaded files and resources, and the export and download durations.

--- a/docs/bulk-data.md
+++ b/docs/bulk-data.md
@@ -54,7 +54,7 @@ Once the kick-off is completed, the status endpoint is available.
 The client uses the URL returned from the `Content-Location` header from the kick-off request to check the job status.
 
 If a `200` status code is returned, the export is complete.
-If a `202` status code is returned, the export is still in progress. The elapsed time is reportedto the user's terminal.
+If a `202` status code is returned, the export is still in progress. The elapsed time is reported to the user's terminal.
 
 ### File Request
 After the export completes, download jobs are creaated to download all the exported resources from the returned file URLs.

--- a/docs/bulk-data.md
+++ b/docs/bulk-data.md
@@ -12,9 +12,10 @@ There are several factors that could impact the time needed to complete a Bulk D
 
 ## Supported Bulk Data Export Client Parameters
 The following parameters are supported by the client:
+
 | Parameter         | Optional?    | Type |Description                                                               |
 | ------------- | -------- | ----| ------------------------------------------------------------------------- |
-| `_outputFormat` | yes | String | The format for the requeted bulk data files to be generated. |
+| `_outputFormat` | yes | String | The format for the requested bulk data files to be generated. |
 | `_since` | yes | FHIR instant | Resources will be included in the response if their state has changed after the supplied time. |
 | `_type` | yes | String | Comma-delimited string of FHIR resoure types to be included in the response. |
 | `_typeFilter` | yes | String | Comma-delimited string of FHIR REST queries. |
@@ -39,9 +40,25 @@ These configuration parameters do not need to be specified when connecting to an
 ## Request Flow
 
 ### Bulk Data Kick-off Request
+A bulk export request is kicked off for a specific group of patients using the following request format:
+
+```
+GET <Base URL>/Group/<Group id>/$export
+```
+
+The Group id must be specified as a configuration option (or specified via the CLI) at the time of kick-off. If request parameters are specified, they are appended to the request url.
+
+Once the kick-off is completed, the status endpoint is available.
 
 ### Bulk Data Status Request
+The client uses the URL returned from the `Content-Location` header from the kick-off request to check the job status.
+
+If a `200` status code is returned, the export is complete.
+If a `202` status code is returned, the export is still in progress. The elapsed time is reportedto the user's terminal.
 
 ### File Request
+After the export completes, download jobs are creaated to download all the exported resources from the returned file URLs.
+
+Each exported NDJSON file contains a single resource type. Multiple files for the same resource type may exist.
 
 For more details on the Bulk Data Export flow, consult the [HL7 Bulk Data specifications](https://hl7.org/fhir/uv/bulkdata/export/index.html).

--- a/docs/bulk-data.md
+++ b/docs/bulk-data.md
@@ -1,0 +1,47 @@
+# Bulk Data Export Details
+
+## Supported Bulk Data Export Endpoints
+Only [Group Export](https://hl7.org/fhir/uv/bulkdata/export/index.html#endpoint---group-of-patients) is supported. The Group Export endpoint is used to export FHIR resources for all members of a [FHIR Group](https://hl7.org/fhir/R4/group.html), referenced by its id. The Group Export operation exports resources required for [United States Core Data for Interoperability V1 (USCDI)](https://www.healthit.gov/isa/united-states-core-data-interoperability-uscdi).
+
+## Server Implementation Considerations
+There are several factors that could impact the time needed to complete a Bulk Data Export request. These factors include:
+- The size of the Group specified for export
+- The number of resources and/or resource types being requested
+- The time range being requested
+- The FHIR server's implementation of Bulk Data Export and its allowable parameters
+
+## Supported Bulk Data Export Client Parameters
+The following parameters are supported by the client:
+| Parameter         | Optional?    | Type |Description                                                               |
+| ------------- | -------- | ----| ------------------------------------------------------------------------- |
+| `_outputFormat` | yes | String | The format for the requeted bulk data files to be generated. |
+| `_since` | yes | FHIR instant | Resources will be included in the response if their state has changed after the supplied time. |
+| `_type` | yes | String | Comma-delimited string of FHIR resoure types to be included in the response. |
+| `_typeFilter` | yes | String | Comma-delimited string of FHIR REST queries. |
+| `_elements` | yes | String | Comma-delimited string of FHIR elements. |
+| `patient` | yes | [Reference](http://hl7.org/fhir/R4/references.html#Reference) | Reference to patient(s) to request resources for |
+| `includeAssociatedData` | yes | String | Comma-delimited string of values. When provided, the Group Export will return or omit a pre-defined set of FHIR resources associated with the request. |
+
+## Constraints on Bulk Data Export Client Parameters
+- `_typeFilter` can be supplied without supplying `_type`, but a server error may be returned depending on constraints set by the server.
+- The `_type` parameter can be automatically populated using the `--auto-populate-type` flag. See [Advanced Topics](/docs/advanced-topics.md) for more information.
+
+## Authorization
+The Bulk Data Export client can connect to secured Bulk Data servers using [SMART Backend Services](http://www.hl7.org/fhir/smart-app-launch/backend-services.html).
+
+The required configuration parameters for connecting to secured servers are as follows:
+- Token Url: the Bulk Data token authorization endpoint
+- Client ID: the Bulk Data client ID
+- Private Key: a path to a file containing the private key used to sign authentication tokens
+
+These configuration parameters do not need to be specified when connecting to an unsecured server.
+
+## Request Flow
+
+### Bulk Data Kick-off Request
+
+### Bulk Data Status Request
+
+### File Request
+
+For more details on the Bulk Data Export flow, consult the [HL7 Bulk Data specifications](https://hl7.org/fhir/uv/bulkdata/export/index.html).


### PR DESCRIPTION
# Summary
Adds new documentation page “Bulk Data Export Details” and adds sections to the “Advanced Topics” page.

## Details
In terms of bulk data flow documentation, adds documentation on the following topics:
- Supported endpoints
- Implementation considerations
- Supported parameters (Client-side)
- Constraints on parameters (Client-side)
- Authorization
- Request flow

In terms of advanced technical features, adds documentation on the following topics:
- Automatic _type population
- Measure report generation
- Export report generation

## Testing guidance
Run the `npm run docs` command and navigate to `localhost:3000` to view the documentation changes locally. Once merged, these changes should be reflected on GH pages since its deployment setting is set to update when the main branch is updated.