### PR TITLE
Add automatic _typeFilter population

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,10 @@ The supported options for making a request to a FHIR server are as follows:
 -t, --_type <resourceTypes> String of comma-delimited FHIR resource types. If omitted, exports resources of all resource types.
 -s, --_since <date> Only include resources modified after the specified date. The parameter can be provided as a partial date.
 -q, --_typeFilter <string> Experimental _typeFilter parameter. Represents a string of comma delimited FHIR REST queries.
--a, --auto-populate-type <boolean> Automatically populates _type using data requirements from the measure bundle. Requires a measure bundle path to be supplied. Overrides any input provided by the --_type flag.
 --from <string> Measurement period start date time. Should be formatted with a string of FHIR dateTime. 
 --to <string> Measurement period end date time. Should be formatted with a string of FHIR dateTime. 
+--auto-populate-type <boolean> Automatically populates _type using data requirements from the measure bundle. Requires a measure bundle path to be supplied. Overrides any input provided by the --_type flag.
+--auto-populate-typeFilter <boolean> Automatically populates _typeFilter using data requirements from the measure bundle. Requires a measure bundle path to be supplied. Overrides any input provided by the --_typeFilter flag.
 --config <path> Relative path to a config file. Otherwise uses default options.
 ```
 

--- a/config/defaults.js
+++ b/config/defaults.js
@@ -84,7 +84,7 @@ module.exports = {
    * The value of the `_type` parameter for Bulk Data kick-off requests.
    * Will be ignored if empty or falsy.
    */
-  _type: '',
+  _type: null,
 
   /**
    * The value of the `_elements` parameter for Bulk Data kick-off requests.

--- a/docs/advanced-topics.md
+++ b/docs/advanced-topics.md
@@ -12,12 +12,16 @@ The client uses the [FHIR Patient Compartment Definition](http://hl7.org/fhir/R4
 3. For each patient, constructs a FHIR Collection Bundle containing the FHIR Patient resource and all downloaded resources that reference the patient.
 4. Writes the collection bundles to the `patientBundles` directory or the user-specified patient bundles directory.
 
-## Automatic `--_type` Population
-Optionally, the client can automatically populate the `_type` parameter using the data requirements of a provided FHIR Measure.
+## Automatic `_type` and `_typeFilter` Population
+Optionally, the client can automatically populate the `_type` and/or `_typeFilter` parameters using the data requirements of a provided FHIR Measure.
 
 To automatically populate the `_type` parameter prior to sending a Bulk Data Export kick-off request, the `--auto-populate-type` CLI flag must be specified, and a measure bundle path must also be specified. When present, the data requirements output will override any input provided by the `--_type` flag.
 
-The client retrieves the data requirements for the given measure using the [fqm-execution](https://github.com/projecttacoma/fqm-execution) `calculateDataRequirements` API function, and then extracts the `type`s from each data requirement that gets returned from the API function.
+To automatically populate the `_typeFilter` parameter prior to sending a Bulk Data Export kick-off request, the `--auto-populate-typeFilter` CLI flag must be specified, and a measure bundle path must also be specified. When present, the data requirements output will override any input provided by the `--_typeFilter` flag.
+
+The client retrieves the data requirements for the given measure using the [fqm-execution](https://github.com/projecttacoma/fqm-execution) `calculateDataRequirements` API function, and then extracts the `type`s from each data requirement that gets returned from the API function to populate the `_type` parameter. The client extracts the `codeFilter`s from each data requirement to populate the `_typeFilter` parameter.
+
+The `--auto-populate-type` and `--auto-populate-typeFilter` options can be used independently.
 
 ## Measure Report Generation
 When a path to a measure bundle is specified, the application runs measure calculation against all the patients that are members of the FHIR Group used for Group Export. The client uses the [fqm-execution](https://github.com/projecttacoma/fqm-execution) `calculateMeasureReports` API function to generate a FHIR MeasureReport of type `summary` that contains a measure score across all the patients.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -171,6 +171,9 @@ const executeExport = async () => {
     const results = await retrieveParamsFromMeasureBundle(mb, autoType, autoTypeFilter);
     if (autoType) {
       options._type = results._type;
+      if (options.patientBundles || options.measureBundle) {
+        options._type = options._type?.concat(',Patient');
+      }
     }
     if (autoTypeFilter) {
       options._typeFilter = results._typeFilter;
@@ -260,6 +263,9 @@ const main = async (options: NormalizedOptions) => {
 
   // execute "Step 1": bulk data export
   if (options.fhirUrl && options.group) {
+    if (options.patientBundles || options.measureBundle) {
+      options._type = options._type?.concat(',Patient');
+    }
     await executeExport();
     // execute "Step 2": generate patient bundles
     if (options.patientBundles || options.measureBundle) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -263,8 +263,9 @@ const main = async (options: NormalizedOptions) => {
 
   // execute "Step 1": bulk data export
   if (options.fhirUrl && options.group) {
-    if (options.patientBundles || options.measureBundle) {
-      options._type = options._type?.concat(',Patient');
+    if ((options.patientBundles || options.measureBundle) && options._type && options._type.length > 0) {
+      // ensure that Patient resources are exported to use for measure calculation
+      options._type = options._type.concat(',Patient');
     }
     await executeExport();
     // execute "Step 2": generate patient bundles

--- a/src/fqm.test.ts
+++ b/src/fqm.test.ts
@@ -126,6 +126,62 @@ describe('constructParamsFromRequirements', () => {
       ],
     },
   ];
+
+  const DR_WITH_MULTIPLE_CODEFILTERS: fhir4.DataRequirement[] = [
+    {
+      type: 'Encounter',
+      codeFilter: [
+        {
+          path: 'status',
+          code: [
+            {
+              code: 'finished',
+              system: 'http://hl7.org/fhir/encounter-status',
+            },
+          ],
+        },
+        {
+          path: 'code',
+          valueSet: 'TEST_VALUE_SET',
+        },
+      ],
+    },
+  ];
+
+  const DR_WITH_DIRECT_REFERENCE_CODE: fhir4.DataRequirement[] = [
+    {
+      type: 'Observation',
+      codeFilter: [
+        {
+          path: 'code',
+          code: [
+            {
+              system: 'http://loinc.org',
+              display: 'Functional Assessment of Chronic Illness Therapy - Palliative Care Questionnaire (FACIT-Pal)',
+              code: '71007-9',
+            },
+          ],
+        },
+        {
+          path: 'status',
+          code: [
+            {
+              code: 'final',
+              system: 'http://hl7.org/fhir/observation-status',
+            },
+            {
+              code: 'amended',
+              system: 'http://hl7.org/fhir/observation-status',
+            },
+            {
+              code: 'corrected',
+              system: 'http://hl7.org/fhir/observation-status',
+            },
+          ],
+        },
+      ],
+    },
+  ];
   const AUTO_TYPE_TRUE = true;
   const AUTO_TYPE_FALSE = false;
   const AUTO_TYPEFILTER_TRUE = true;
@@ -152,6 +208,22 @@ describe('constructParamsFromRequirements', () => {
     expect(constructParamsFromRequirements(MULTIPLE_DR, AUTO_TYPE_TRUE, AUTO_TYPEFILTER_TRUE)).toEqual({
       _type: 'Procedure,Encounter',
       _typeFilter: 'Procedure?type:in=TEST_VALUE_SET,Encounter?code:in=TEST_VALUE_SET',
+    });
+  });
+
+  test('generates _typeFilter when multiple codeFilters are present on a data requirement', () => {
+    expect(
+      constructParamsFromRequirements(DR_WITH_MULTIPLE_CODEFILTERS, AUTO_TYPE_FALSE, AUTO_TYPEFILTER_TRUE)
+    ).toEqual({
+      _typeFilter: 'Encounter?code:in=TEST_VALUE_SET',
+    });
+  });
+
+  test('generates _typeFilter for direct reference code', () => {
+    expect(
+      constructParamsFromRequirements(DR_WITH_DIRECT_REFERENCE_CODE, AUTO_TYPE_FALSE, AUTO_TYPEFILTER_TRUE)
+    ).toEqual({
+      _typeFilter: 'Observation?code=71007-9',
     });
   });
 });

--- a/src/fqm.test.ts
+++ b/src/fqm.test.ts
@@ -144,14 +144,14 @@ describe('constructParamsFromRequirements', () => {
 
   test('generates _typeFilter query for multiple resource types', () => {
     expect(constructParamsFromRequirements(MULTIPLE_DR, AUTO_TYPE_FALSE, AUTO_TYPEFILTER_TRUE)).toEqual({
-      _typeFilter: 'Procedure%3Ftype%3Ain=TEST_VALUE_SET,Encounter%3Fcode%3Ain=TEST_VALUE_SET',
+      _typeFilter: 'Procedure?type:in=TEST_VALUE_SET,Encounter?code:in=TEST_VALUE_SET',
     });
   });
 
   test('generates _type and _typeFilter for multiple resource types', () => {
     expect(constructParamsFromRequirements(MULTIPLE_DR, AUTO_TYPE_TRUE, AUTO_TYPEFILTER_TRUE)).toEqual({
       _type: 'Procedure,Encounter',
-      _typeFilter: 'Procedure%3Ftype%3Ain=TEST_VALUE_SET,Encounter%3Fcode%3Ain=TEST_VALUE_SET',
+      _typeFilter: 'Procedure?type:in=TEST_VALUE_SET,Encounter?code:in=TEST_VALUE_SET',
     });
   });
 });

--- a/src/fqm.test.ts
+++ b/src/fqm.test.ts
@@ -226,4 +226,182 @@ describe('constructParamsFromRequirements', () => {
       _typeFilter: 'Observation?code=71007-9',
     });
   });
+
+  test('generates _typeFilter for date filter with valueDateTime', () => {
+    const DR_WITH_VALUE_DATETIME: fhir4.DataRequirement[] = [
+      {
+        type: 'Observation',
+        dateFilter: [
+          {
+            path: 'testPath',
+            valueDateTime: '2022-01-01T00:00:00.000Z',
+          },
+        ],
+      },
+    ];
+    expect(constructParamsFromRequirements(DR_WITH_VALUE_DATETIME, AUTO_TYPE_FALSE, AUTO_TYPEFILTER_TRUE)).toEqual({
+      _typeFilter: 'Observation?testPath=eq2022-01-01T00:00:00.000Z',
+    });
+  });
+
+  test('generates _typeFilter for date filter with valuePeriod (no end)', () => {
+    const DR_WITH_VALUE_PERIOD: fhir4.DataRequirement[] = [
+      {
+        type: 'Observation',
+        dateFilter: [
+          {
+            path: 'testPath',
+            valuePeriod: {
+              start: '2022-01-01T00:00:00.000Z',
+            },
+          },
+        ],
+      },
+    ];
+    expect(constructParamsFromRequirements(DR_WITH_VALUE_PERIOD, AUTO_TYPE_FALSE, AUTO_TYPEFILTER_TRUE)).toEqual({
+      _typeFilter: 'Observation?testPath=ge2022-01-01T00:00:00.000Z',
+    });
+  });
+
+  test('generates _typeFilter for date filter with valuePeriod (no start)', () => {
+    const DR_WITH_VALUE_PERIOD: fhir4.DataRequirement[] = [
+      {
+        type: 'Observation',
+        dateFilter: [
+          {
+            path: 'testPath',
+            valuePeriod: {
+              end: '2022-01-01T00:00:00.000Z',
+            },
+          },
+        ],
+      },
+    ];
+    expect(constructParamsFromRequirements(DR_WITH_VALUE_PERIOD, AUTO_TYPE_FALSE, AUTO_TYPEFILTER_TRUE)).toEqual({
+      _typeFilter: 'Observation?testPath=le2022-01-01T00:00:00.000Z',
+    });
+  });
+
+  test('generates _typeFilter for date filter with valuePeriod (start and end)', () => {
+    const DR_WITH_VALUE_PERIOD: fhir4.DataRequirement[] = [
+      {
+        type: 'Observation',
+        dateFilter: [
+          {
+            path: 'testPath',
+            valuePeriod: {
+              start: '2022-01-01T00:00:00.000Z',
+              end: '2022-12-31T00:00:00.000Z',
+            },
+          },
+        ],
+      },
+    ];
+    expect(constructParamsFromRequirements(DR_WITH_VALUE_PERIOD, AUTO_TYPE_FALSE, AUTO_TYPEFILTER_TRUE)).toEqual({
+      _typeFilter: 'Observation?testPath=ge2022-01-01T00:00:00.000Z&testPath=le2022-12-31T00:00:00.000Z',
+    });
+  });
+
+  test('generates _typeFilter for date filter with valuePeriod (invalid start and end)', () => {
+    const DR_WITH_VALUE_PERIOD: fhir4.DataRequirement[] = [
+      {
+        type: 'Observation',
+        dateFilter: [
+          {
+            path: 'testPath',
+            valuePeriod: {
+              start: '2022-12-31T00:00:00.000Z',
+              end: '2022-01-01T00:00:00.000Z',
+            },
+          },
+        ],
+      },
+    ];
+    try {
+      constructParamsFromRequirements(DR_WITH_VALUE_PERIOD, AUTO_TYPE_FALSE, AUTO_TYPEFILTER_TRUE);
+    } catch (e) {
+      if (e instanceof Error)
+        expect(e.message).toEqual('Date filter start value SHALL have a lower or equal value than end.');
+    }
+  });
+
+  test('generates _typeFilter for date filter for valueDuration with comparator defined', () => {
+    const DR_WITH_VALUE_DURATION: fhir4.DataRequirement[] = [
+      {
+        type: 'Observation',
+        dateFilter: [
+          {
+            path: 'testPath',
+            valueDuration: {
+              comparator: '>',
+              value: 10,
+            },
+          },
+        ],
+      },
+    ];
+    expect(constructParamsFromRequirements(DR_WITH_VALUE_DURATION, AUTO_TYPE_FALSE, AUTO_TYPEFILTER_TRUE)).toEqual({
+      _typeFilter: 'Observation?testPath=gt10',
+    });
+  });
+
+  test('generates _typeFilter for date filter with valueDuration without comparator defined', () => {
+    const DR_WITH_VALUE_DURATION: fhir4.DataRequirement[] = [
+      {
+        type: 'Observation',
+        dateFilter: [
+          {
+            path: 'testPath',
+            valueDuration: {
+              value: 10,
+            },
+          },
+        ],
+      },
+    ];
+    expect(constructParamsFromRequirements(DR_WITH_VALUE_DURATION, AUTO_TYPE_FALSE, AUTO_TYPEFILTER_TRUE)).toEqual({
+      _typeFilter: 'Observation?testPath=eq10',
+    });
+  });
+
+  test('generates _typeFilter for date filter with valueDuration with value, system, and code', () => {
+    const DR_WITH_VALUE_DURATION: fhir4.DataRequirement[] = [
+      {
+        type: 'Observation',
+        dateFilter: [
+          {
+            path: 'testPath',
+            valueDuration: {
+              value: 10,
+              system: 'testSystem',
+              code: 'testCode',
+            },
+          },
+        ],
+      },
+    ];
+    expect(constructParamsFromRequirements(DR_WITH_VALUE_DURATION, AUTO_TYPE_FALSE, AUTO_TYPEFILTER_TRUE)).toEqual({
+      _typeFilter: 'Observation?testPath=eq10|testSystem|testCode',
+    });
+  });
+
+  test('generates _typeFilter for date filter with valueDuration with value and code', () => {
+    const DR_WITH_VALUE_DURATION: fhir4.DataRequirement[] = [
+      {
+        type: 'Observation',
+        dateFilter: [
+          {
+            path: 'testPath',
+            valueDuration: {
+              value: 10,
+              code: 'testCode',
+            },
+          },
+        ],
+      },
+    ];
+    expect(constructParamsFromRequirements(DR_WITH_VALUE_DURATION, AUTO_TYPE_FALSE, AUTO_TYPEFILTER_TRUE)).toEqual({
+      _typeFilter: 'Observation?testPath=eq10||testCode',
+    });
+  });
 });

--- a/src/fqm.ts
+++ b/src/fqm.ts
@@ -82,6 +82,16 @@ export const constructParamsFromRequirements = (
     if (dr.type) {
       types.push(dr.type);
       const query: { type: string; params: Record<string, string> } = { type: dr.type, params: {} };
+
+      dr?.codeFilter?.forEach((codeFilter) => {
+        if (codeFilter.valueSet) {
+          const key = `${codeFilter.path}:in`;
+          key && (query.params[key] = codeFilter.valueSet);
+        } else if (codeFilter.path === 'code' && codeFilter.code?.[0].code) {
+          const key = codeFilter.path;
+          key && (query.params[key] = codeFilter.code[0].code);
+        }
+      });
       if (dr?.codeFilter?.[0]?.valueSet) {
         const key = `${dr?.codeFilter?.[0].path}:in`;
         key && (query.params[key] = dr.codeFilter[0].valueSet);

--- a/src/fqm.ts
+++ b/src/fqm.ts
@@ -82,10 +82,7 @@ export const constructParamsFromRequirements = (
     if (dr.type) {
       types.push(dr.type);
       const query: { type: string; params: Record<string, string> } = { type: dr.type, params: {} };
-      if (dr?.codeFilter?.[0]?.code?.[0].code) {
-        const key = dr?.codeFilter?.[0].path;
-        key && (query.params[key] = dr.codeFilter[0].code[0].code);
-      } else if (dr?.codeFilter?.[0]?.valueSet) {
+      if (dr?.codeFilter?.[0]?.valueSet) {
         const key = `${dr?.codeFilter?.[0].path}:in`;
         key && (query.params[key] = dr.codeFilter[0].valueSet);
       }
@@ -103,7 +100,10 @@ export const constructParamsFromRequirements = (
   const formattedTypeParam = uniqueTypes.join(',');
   const typeFilterQueries = queries.reduce((acc: string[], e) => {
     if (Object.keys(e.params).length > 0) {
-      acc.push(`${e.type}%3F${new URLSearchParams(e.params).toString()}`);
+      const entry = Object.entries(e.params).map(([key, val]) => {
+        return `${key}=${val}`;
+      });
+      acc.push(`${e.type}?${entry.join('&')}`);
     }
     return acc;
   }, []);

--- a/src/fqm.ts
+++ b/src/fqm.ts
@@ -92,10 +92,6 @@ export const constructParamsFromRequirements = (
           key && (query.params[key] = codeFilter.code[0].code);
         }
       });
-      if (dr?.codeFilter?.[0]?.valueSet) {
-        const key = `${dr?.codeFilter?.[0].path}:in`;
-        key && (query.params[key] = dr.codeFilter[0].valueSet);
-      }
       queries.push(query);
     }
   });


### PR DESCRIPTION
# Summary
Adds support for automatic `_typeFilter` population. Forms the `_typeFilter` query from the data requirements of a given FHIR Measure that is passed in for measure calculation on the exported data.

## Purpose
One goal for the upcoming Connectathon is to test whether we can run successful measure calculation on the tightest set of data (i.e. the exported resources). Narrowing down the exported data via the data requirements is an approach that can be used for reducing the amount of data used for measure calculation. At the Connectathon, we will likely test the use of automatic parameter population against standard Group export to compare how many resources get returned and whether the final measure score is the same across different sets of exported data.

## New behavior
Exposes new CLI option `--auto-populate-typeFilter`, which automatically populates `_typeFilter` based on the data requirements from the measure bundle. Requires that a path to a measure bundle is specified at runtime.

The automatic `_typeFilter` population can be used independent of or in conjunction with `_type`. Although the wording around the `_type`/`_typeFilter` dependence is a little unclear in the [Bulk Data Export specifications](https://hl7.org/fhir/uv/bulkdata/export/index.html#experimental-query-parameters), Josh Mandel clarified on a call that `_typeFilter` can be used independently of `_type`, although some servers have implemented a dependency constraint between the two parameters.

When the CLI option is used, if a `_typeFilter` query was supplied by other means, it will be overwritten by the automatic `_typeFilter` queries from the measure’s data requirements.

## Code changes
* `src/fqm.ts` - Did some refactoring to allow for the `_type` and `_typeFilter` population to occur in a single function. Added support for `_typeFilter` population via parsing the `codeFilter` on each data requirement. 
* `src/fqm.test.ts` - Added unit tests for `_typeFilter` population with and without automatic `_type` population also being specified
* `src/cli.ts` - Added new CLI option. Also removed `-a` option for `--auto-populate-type` to avoid confusion. For automatic `_type` population, added `Patient` to list of types so that measure calculation can be successfully executed on the data (otherwise there will be no bundles to pass in).
* `README.md`, `advanced-topics.md` - Added documentation on the new option

# Testing Guidance
1. Run unit tests with `npm run test`
2. Run the following scenarios:

* Run the client CLI without the use of `_type` or `_typeFilter`:

```bash
npm run cli -- -f <export url> -g <group id> -m <measure bundle path> 
```

* Run the client CLI with the use of `--auto-populate-typeFilter`:
```bash
npm run cli -- -f <export url> -g <group id> -m <measure bundle path>  --auto-populate-typeFilter
```
* Run the client CLI with the use of `--auto-populate-typeFilter` and `--auto-populate-type`:
```bash
npm run cli -- -f <export url> -g <group id> -m <measure bundle path>  --auto-populate-typeFilter --auto-populate-type
```

Expected results: The export that does not use any filtering parameters should export the largest number of resources. The export that uses automatic `_typeFilter` population should export a lower number of resources, and the export that uses both `_typeFilter` and `_type` population should export the lowest number of resources. 

When doing this testing, inspect the `_typeFilter` query that gets constructed to ensure that it is in the correct format (i.e. comma-delimited queries of the format `<resource type>?<property>=<property value>`).

*NOTE*: Most servers do not support `_typeFilter`, which makes the testing tricky for this PR. I recommend testing against this branch of the projecttacoma bulk export server: https://github.com/projecttacoma/bulk-export-server/tree/vs-bug-fix (the branch contains a bug fix that has not yet been reflected on the main branch)

**UPDATE (9/6):**
Added support for date filters. Pulls the date filter values and constructs queries accordingly. When testing, the number of resources returned should be smaller than the number of resources previously returned (when date filter support was not implemented)