### PR TITLE
Update NDJSON extraction to be more generalized

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -113,13 +113,21 @@ Sets logging events for logging responses and status updates throughout the expo
 Converts downloaded NDJSON content to FHIR Bundles for each patient in the requested FHIR Group.
 
 ### getNDJSONFromDir
-Retrieves NDJSON content for a specified resource type from a given directory.
+Retrieves NDJSON content for a given file from a given directory.
 
 | Param         | Type     | Description                                                               |
 | ------------- | -------- | ------------------------------------------------------------------------- |
 | dir | `String` | Path to directory containing downloaded NDJSON. |
-| resourceType | `String` | Resource type to retrieve NDJSON for
-| **Returns**   | `fhir4.FhirResource[]`  | Returns array of parsed NDJSON, cast to FHIR Resources       
+| file | `String` | file name containing the resources to convert to NDJSON
+| **Returns**   | `fhir4.FhirResource[]`  | Returns array of parsed NDJSON, cast to FHIR Resources
+
+### findPatientFiles
+Loops over all files in a given directory to infer which files contain Patient resources.
+
+| Param         | Type     | Description                                                               |
+| ------------- | -------- | ------------------------------------------------------------------------- |
+| dir | `String` | Path to directory containing downloaded NDJSON. |
+| **Returns**   | `string[]`  | Array of file names for files containing Patient resources
 
 ### mapResourcesToCollectionBundle
 Creates FHIR Collection [Bundle](https://www.hl7.org/fhir/bundle.html) from given FHIR resources.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@ import TextReporter from 'bulk-data-client/built/reporters/text';
 import { resolveJWK } from './jwk';
 import * as Logger from 'bulk-data-client/built/loggers/index';
 import { createExportReport } from './reportGenerator';
-import { assemblePatientBundle, getNDJSONFromDir } from './ndjsonToBundle';
+import { assemblePatientBundle, findPatientFiles, getNDJSONFromDir } from './ndjsonToBundle';
 import { writeFile } from 'fs';
 import { CalculatorTypes } from 'fqm-execution';
 import {
@@ -188,7 +188,12 @@ const executeExport = async () => {
  */
 const createPatientBundles = (patientBundleDir: string) => {
   const bundleDirectory = resolve(patientBundleDir);
-  const parsedNDJSON = getNDJSONFromDir(options.destination, 'Patient');
+  const patientFiles = findPatientFiles(resolve(options.destination));
+  const parsedNDJSON = patientFiles.reduce((acc: fhir4.FhirResource[], patientFile: string) => {
+    const ndjson = getNDJSONFromDir(options.destination, patientFile);
+    acc.push(...ndjson);
+    return acc;
+  }, []);
   if (!fs.existsSync(bundleDirectory)) {
     fs.mkdirSync(bundleDirectory, { recursive: true });
   }


### PR DESCRIPTION
# Summary
Updates the method by which the client traverses through the downloaded `.ndjson` files to construct patient bundles for measure calculation.

## Code changes
* Update documentation to reflect new function, new inputs/outputs to functions, etc.
* Update `ndjsonToBundle.ts` to no longer search for a specific file name format for the files. Instead, does the following:
    * Uses new function `findPatientFiles` to traverse through the downloaded files and collect file names for all files that contain Patient resources. Throws error if no Patient resources can be found.
    * Uses the Patient files to then go through all the downloaded files, parse them to FHIR Resources, and map all resources to the FHIR Patients that they reference
* Add/update unit tests

## Testing guidance
* Run unit tests
* Run an export request in order to obtain downloaded NDJSON files
* Once a directory is populated with downloaded files, run `npm run cli -- -d <path to downloads directory>`, which will pull the files from that directory to form the FHIR Bundles for each patient. Check that the correct amount of bundles are created (ex. If the group has 10 patients, the `patientBundles` directory should have 10 JSON files)
* Test edge cases - delete the Patient NDJSON file and run the above command again. Check that an error is thrown. Also check that the bundles can be generated when there are multiple patient files by splitting the Patient NDJSON into multiple files, and then running the above command.